### PR TITLE
Update 'discussion thread'-related persistence and handling

### DIFF
--- a/discord_taskbot/bot.py
+++ b/discord_taskbot/bot.py
@@ -174,9 +174,6 @@ async def edit_task(interaction: discord.Interaction):
             await interaction.followup.send(f"Something went wrong while updating task {t.number}.")
         else:
             await interaction.followup.send(f"Successfully updated task {t.number}. ")
-            if str(new_title).strip() != "":
-                c = await BOT.fetch_channel(interaction.channel.id)
-                await c.edit(name=BOT.generate_task_thread_title(t))
 
     modal = BOT.generate_edit_task_modal(t.title, t.description, modal_func)
     await interaction.response.send_modal(modal())

--- a/discord_taskbot/bot.py
+++ b/discord_taskbot/bot.py
@@ -72,7 +72,7 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
         case 'open_discussion':
             thread = await message.create_thread(name=BOT.generate_task_thread_title(task))
             try:
-                BOT.db.update_task_thread_id(task.id, thread.id)
+                BOT.db.update_task(task.id, has_thread=True)
             except CannotBeUpdated:
                 # TODO don't use pass but something else, this is hard to debug
                 pass
@@ -112,7 +112,7 @@ async def new_task(interaction: discord.Interaction, title: str, description: st
 
     # TODO first send task content, secondly update task message id and then send task action emojis
 
-    BOT.db.update_task_message_id(task.id, message.id)
+    BOT.db.update_task(task.id, message_id=message.id)
 
     await interaction.followup.send(f"Task created successfully.")
     await asyncio.sleep(1)
@@ -138,7 +138,7 @@ async def new_task_modal(interaction: discord.Interaction):
         # TODO first, send message with task content, second store message id for task, then add reactions to message
 
         message: discord.Message = await BOT.send_new_task(interaction.channel, task)
-        BOT.db.update_task_message_id(task.id, message.id)
+        BOT.db.update_task(task.id, message_id=message.id)
         await interaction.edit_original_response(content=f"Task created successfully.")
         await asyncio.sleep(1)
         await interaction.delete_original_response()

--- a/discord_taskbot/components/client.py
+++ b/discord_taskbot/components/client.py
@@ -122,8 +122,8 @@ class TaskBot(discord.Client):
             m = await c.fetch_message(t.message_id)
             await m.edit(content=self.generate_task_string(t))
 
-        if t.thread_id and t.thread_id != -1:
-            thread = await self.fetch_channel(t.thread_id)
+        if t.has_thread:
+            thread = await self.fetch_channel(t.message_id)
             await thread.edit(name=self.generate_task_thread_title(t))
 
             if status_id != 'done':

--- a/discord_taskbot/components/client.py
+++ b/discord_taskbot/components/client.py
@@ -162,15 +162,15 @@ class TaskBot(discord.Client):
         """Generate a string to use as a Discord thread title."""
         return f"[{task.number}{(', ' + TASK_STATUS_MAPPING[task.status]) if task.status else ''}] {task.title}"
 
-    async def update_task(self, task_id: int, name: str = "", description: str = "", status: str = "",
-                          assigned_to: int = "") -> None:
+    async def update_task(self, task_id: int, name: str = None, description: str = None, status: str = None,
+                          assigned_to: int = None, message_id: int = None, has_thread: bool = None) -> None:
         """Update a task and it's connected message content."""
 
-        if not name and not description and not status and not assigned_to:
+        if (name, description, status, assigned_to, message_id, has_thread) == (None, None, None, None, None, None):
             return
 
         try:
-            t = self.db.update_task(task_id, name, description, status, assigned_to)
+            t = self.db.update_task(task_id, name, description, status, assigned_to, message_id, has_thread)
         except TaskDoesNotExist:
             return
 

--- a/discord_taskbot/components/data_classes.py
+++ b/discord_taskbot/components/data_classes.py
@@ -165,7 +165,7 @@ class Task(Data):
 
     @property
     def has_thread(self) -> int:
-        return self.has_thread
+        return self._has_thread
 
 
 class Value(Data):

--- a/discord_taskbot/components/data_classes.py
+++ b/discord_taskbot/components/data_classes.py
@@ -88,11 +88,11 @@ class Task(Data):
     _status: str
     _assigned_to: int
     _message_id: int
-    _thread_id: int
+    _has_thread: int
 
     def __init__(self, task_id: int = None, related_project_id: int = None, number: int = None, title: str = None,
                  description: str = None, status: str = None, assigned_to: int = None, message_id: int = None,
-                 thread_id: int = None) -> None:
+                 has_thread: bool = None) -> None:
         """
         Task information.
 
@@ -105,7 +105,8 @@ class Task(Data):
             status              Task status. Either 'pending', 'in_progress', 'pending_merge' or 'done'.
             assigned_to         Discord user id who this task is assigned to.
             message_id          Discord message id of the task's in-discord message.
-            thread_id           Discord thread id of the task's in-discord discussion thread.
+            has_thread          Whether a task's discussion thread has been opened.
+                                A thread's channel id equals its origin message id
         """
 
         self._id = int(task_id) if task_id is not None else None
@@ -116,7 +117,7 @@ class Task(Data):
         self._status = str(status).strip() if status is not None else None
         self._assigned_to = int(assigned_to) if assigned_to is not None else None
         self._message_id = int(message_id) if message_id is not None else None
-        self._thread_id = int(thread_id) if thread_id is not None else None
+        self._has_thread = bool(has_thread) if has_thread is not None else None
 
         super().__init__()
 
@@ -163,8 +164,8 @@ class Task(Data):
         return self._message_id
 
     @property
-    def thread_id(self) -> int:
-        return self._thread_id
+    def has_thread(self) -> int:
+        return self.has_thread
 
 
 class Value(Data):

--- a/discord_taskbot/components/data_classes.py
+++ b/discord_taskbot/components/data_classes.py
@@ -129,7 +129,7 @@ class Task(Data):
             raise TypeError(f"Passed project is type {type(orm_task)} not ORM_Task.")
 
         return Task(orm_task.id, orm_task.related_project_id, orm_task.number, orm_task.title, orm_task.description,
-                    orm_task.status, orm_task.assigned_to, orm_task.message_id, orm_task.thread_id)
+                    orm_task.status, orm_task.assigned_to, orm_task.message_id, orm_task.has_thread)
 
     @property
     def id(self) -> int:

--- a/discord_taskbot/components/models.py
+++ b/discord_taskbot/components/models.py
@@ -2,7 +2,7 @@
 ORM models.
 """
 
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Boolean
 from sqlalchemy.orm import declarative_base
 
 ORM_BASE = declarative_base()
@@ -35,7 +35,7 @@ class ORM_Task(ORM_BASE):
     status = Column(String, nullable=False)
     assigned_to = Column(Integer)
     message_id = Column(Integer, nullable=False, default=-1)
-    thread_id = Column(Integer)
+    has_thread = Column(Boolean, nullable=False, default=False)
 
 
 class ORM_Value(ORM_BASE):

--- a/discord_taskbot/components/persistence.py
+++ b/discord_taskbot/components/persistence.py
@@ -250,39 +250,6 @@ class PersistenceAPI:
 
             return Task.from_orm(t)
 
-    def update_task_message_id(self, task_id: int, message_id: int) -> None:
-        """Update a task's message id."""
-
-        with Session(self._engine) as session:
-            t: ORM_Task = session.query(ORM_Task).filter(ORM_Task.id == task_id).first()
-
-            if not t:
-                raise TaskDoesNotExist(f"Task with id '{task_id}' does not exist.")
-
-            if t.message_id != -1:
-                raise CannotBeUpdated(
-                    f"Message id of {task_id} cannot be updated because it already has a valid value.")
-
-            t.message_id = message_id
-
-            session.commit()
-
-    def update_task_thread_id(self, task_id: int, thread_id: int) -> None:
-        """Update a task's thread id."""
-
-        with Session(self._engine) as session:
-            t: ORM_Task = session.query(ORM_Task).filter(ORM_Task.id == task_id).first()
-
-            if not t:
-                raise TaskDoesNotExist(f"Task with id '{task_id}' does not exist.")
-
-            if t.thread_id and t.thread_id != -1:
-                raise CannotBeUpdated(f"Thread id of {task_id} cannot be updated because it already has a valid value.")
-
-            t.thread_id = thread_id
-
-            session.commit()
-
     def get_project(self, tag: str = None, project_id: int = None, channel_id: int = None) -> Project | None:
         """Get a project from a unique project value. Returns the Project or None if no results."""
 

--- a/discord_taskbot/components/persistence.py
+++ b/discord_taskbot/components/persistence.py
@@ -160,10 +160,10 @@ class PersistenceAPI:
 
             return Project.from_orm(p)
 
-    def update_project(self, tag: str, display_name: str = "", description: str = "") -> Project:
+    def update_project(self, tag: str, display_name: str = None, description: str = None) -> Project:
         """Update a project's display name and description."""
-        display_name = str(display_name).strip()
-        description = str(description).strip()
+        display_name = str(display_name).strip() if display_name is not None else None
+        description = str(description).strip() if description is not None else None
 
         with Session(self._engine) as session:
             p: ORM_Project = session.get(ORM_Project, tag)
@@ -205,13 +205,16 @@ class PersistenceAPI:
 
             return Task.from_orm(t)
 
-    def update_task(self, task_id: int, name: str = "", description: str = "", status: str = "",
-                    assigned_to: int = "") -> Task:
+    def update_task(self, task_id: int, title: str = None, description: str = None, status: str = None,
+                    assigned_to: int = None, message_id: int = None, has_thread: bool = None) -> Task:
         """Update a task."""
 
-        name = str(name).strip()
-        description = str(description).strip()
-        status = str(status).strip()
+        title = str(title).strip() if title is not None else None
+        description = str(description).strip() if description is not None else None
+        status = str(status).strip() if status is not None else None
+        assigned_to = int(assigned_to) if assigned_to is not None else None
+        message_id = int(message_id) if message_id is not None else None
+        has_thread = bool(has_thread) if has_thread is not None else None
 
         with Session(self._engine) as session:
 
@@ -219,8 +222,8 @@ class PersistenceAPI:
             if not t:
                 raise TaskDoesNotExist(f"Task with id '{task_id}' does not exist.")
 
-            if name:
-                t.title = name
+            if title:
+                t.title = title
 
             if description:
                 t.description = description
@@ -230,6 +233,18 @@ class PersistenceAPI:
 
             if assigned_to:
                 t.assigned_to = int(assigned_to)
+
+            if message_id:
+                if t.message_id != -1:
+                    raise CannotBeUpdated(f"Message id of {task_id} cannot be updated because it already has a valid value.")
+
+                t.message_id = message_id
+
+            if has_thread:
+                if t.has_thread:
+                    raise CannotBeUpdated(f"Thread status of {task_id} cannot be updated because it already has a valid value.")
+
+                t.has_thread = True
 
             session.commit()
 
@@ -254,11 +269,6 @@ class PersistenceAPI:
 
     def update_task_thread_id(self, task_id: int, thread_id: int) -> None:
         """Update a task's thread id."""
-
-        # TODO different API soon
-
-        # TODO technically, we don't need any checks. According to the docs, the thread-id is the same
-        # as the thread's origin message
 
         with Session(self._engine) as session:
             t: ORM_Task = session.query(ORM_Task).filter(ORM_Task.id == task_id).first()
@@ -308,12 +318,18 @@ class PersistenceAPI:
         return None
 
     def get_task(self, task_id: int = None, message_id: int = None, thread_id: int = None) -> Task | None:
-        """Get a task from a unique task value. Returns the Task or None if no results."""
+        """
+        Get a task from a unique task value. Returns the Task or None if no results.
+        thread_id is a synonym for message_id.
+        """
 
         try:
             task_id = int(task_id) if task_id is not None else None
             message_id = int(message_id) if message_id is not None else None
-            thread_id = int(thread_id) if thread_id is not None else None
+
+            if thread_id is not None:
+                message_id = int(thread_id)
+
         except TypeError:
             raise
         except ValueError:
@@ -330,11 +346,6 @@ class PersistenceAPI:
 
             if message_id and message_id != -1:
                 t = session.query(ORM_Task).filter(ORM_Task.message_id == message_id).first()
-                if t:
-                    return Task.from_orm(t)
-
-            if thread_id and thread_id != -1:
-                t = session.query(ORM_Task).filter(ORM_Task.thread_id == thread_id).first()
                 if t:
                     return Task.from_orm(t)
 


### PR DESCRIPTION
A discord thread's channel_id is equal to the message_id from which it was created from (see https://discord.com/developers/docs/topics/threads, last access: 08-10-2022; `The created thread and the message it was started from will share the same id`). This means it is unneccessary to store a thread_id when the message_id is already stored.

This pull request changes the thread_id column to a has_thread (boolean) column + plus some other minor changes and fixes including:
* one big method for updating tasks (instead of one general and two owns for message_id and thread_id)
* bugfix where thread titles would not get updated correctly on task edits
* moved thread title updating in client.update_task() method